### PR TITLE
feat: update non-member message on check-club-user block

### DIFF
--- a/store/blocks/pdp/product-price.jsonc
+++ b/store/blocks/pdp/product-price.jsonc
@@ -56,7 +56,7 @@
   "check-club-user#price": {
     "children": ["product-list-price#summary", "product-selling-price#summary"],
     "props": {
-      "fallbackMessage": "Inscreva-se no nosso clube de compras para poder acessar preços e adicionar produtos ao seu pedido."
+      "fallbackMessage": "Inscreva-se no nosso clube de compras para poder acessar a loja."
     }
   },
   /* Futura Estrutura da PdP*/


### PR DESCRIPTION
### What problem is this solving?

Replaces the outdated fallback message shown to non-club users with the new copy provided by the Clube de Compras team.


### How to test it?

1. Open a workspace without being logged into the club.
2. Scroll to a product card.
3. You should see the new message:  
   _"Inscreva-se no nosso clube de compras para poder acessar a loja."_


### [Workspace](https://raabelo--clubetoolstore.myvtex.com)


### Screenshots or example usage:

![image](https://github.com/user-attachments/assets/2897ae29-fe44-46e9-9f21-0e71cd34ad45)
